### PR TITLE
Switch from deprecated arma::syl() to arma::sylvester()

### DIFF
--- a/src/cpp_casket.cpp
+++ b/src/cpp_casket.cpp
@@ -172,7 +172,7 @@ arma::vec dat2centers(arma::rowvec data, arma::mat &centers){
 // [[Rcpp::export]]
 arma::mat cpp_sylvester(arma::mat A, arma::mat B, arma::mat C){
   arma::mat solution;
-  arma::syl(solution,A,B,C);
+  arma::sylvester(solution,A,B,C);
   return(solution);
 }
 
@@ -180,7 +180,7 @@ arma::mat cpp_sylvester(arma::mat A, arma::mat B, arma::mat C){
 arma::mat solve_lyapunov(arma::mat A, arma::mat B, arma::mat C){
   // simply solve it !
   arma::mat solution;
-  arma::syl(solution, A, B, C);
+  arma::sylvester(solution, A, B, C);
   return(solution);
 }
 


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard, which also means I can no-longer add the suppression of deprecation warnings (which used a macro before and now use a C++14 or later attribute). For most packages, adapting to it can be very simple, and yours is one of them -- in fact it is just two statements changing `syl()` to `sylvester()`. In the patch below we simply update this as now required by Armadillo 15.0.x.  

Please see issues [#475](https://github.com/RcppCore/RcppArmadillo/issues/475) and below at the RcppArmadillo GitHub repo for context, and notably [#491](https://github.com/RcppCore/RcppArmadillo/issues/491) for this second wave of PRs and patches (following one for moving away from C++11, something your package does not need). It would be terrific if you could make an upload to CRAN 'soon' to remove the deprecation warning. Please do not hesitate to reach out if I can assist in any way or clarify matters.